### PR TITLE
fix: add CommunityDataProvider cache and fix data caching on load

### DIFF
--- a/.yarn/versions/772c6242.yml
+++ b/.yarn/versions/772c6242.yml
@@ -1,2 +1,5 @@
 releases:
   "@essex-js-toolkit/hierarchy-browser": patch
+
+declined:
+  - "@essex-js-toolkit/dev"

--- a/.yarn/versions/772c6242.yml
+++ b/.yarn/versions/772c6242.yml
@@ -1,0 +1,2 @@
+releases:
+  "@essex-js-toolkit/hierarchy-browser": patch

--- a/packages/hierarchy-browser/src/CommunityCard/CommunityCard.tsx
+++ b/packages/hierarchy-browser/src/CommunityCard/CommunityCard.tsx
@@ -69,10 +69,6 @@ export const CommunityCard: React.FC<ICommunityCardProps> = memo(
 			isAdjacentEntitiesLoading,
 		] = useAdjacentCommunityData(dataProvider, isOpen, neighborsLoaded)
 
-		const size = useMemo(() => dataProvider.size, [dataProvider.size])
-		const neighborSize = useMemo(() => dataProvider.neighborSize, [
-			dataProvider.neighborSize,
-		])
 		const [
 			setEdgeSelection,
 			loadMoreEntities,
@@ -81,7 +77,7 @@ export const CommunityCard: React.FC<ICommunityCardProps> = memo(
 			selectedCommunityEdge,
 			clearCurrentSelection,
 		] = useEdgeSelection(dataProvider)
-		const sizePercent = useCommunitySizePercent(size, maxSize)
+		const sizePercent = useCommunitySizePercent(dataProvider.size, maxSize)
 		const contentStyle = useContainerStyle(isOpen, entities.length > 0)
 
 		const loadingElement = useMemo(
@@ -103,8 +99,8 @@ export const CommunityCard: React.FC<ICommunityCardProps> = memo(
 					level={level}
 					fontStyles={fontStyles}
 					controls={controls}
-					neighborSize={neighborSize}
-					size={size}
+					neighborSize={dataProvider.neighborSize}
+					size={dataProvider.size}
 				/>
 				<Flex>
 					<Content style={contentStyle}>

--- a/packages/hierarchy-browser/src/CommunityCard/CommunityCard.tsx
+++ b/packages/hierarchy-browser/src/CommunityCard/CommunityCard.tsx
@@ -5,12 +5,11 @@
 import { Spinner } from '@fluentui/react'
 import React, { memo, useMemo } from 'react'
 import styled from 'styled-components'
-import { ICommunityDetail, ILoadNeighborCommunities } from '..'
+import { ILoadNeighborCommunities } from '..'
 import { EmptyEntityList } from '../EntityItem/EmptyEntityList'
 import CommunityEdgeList from '../NeighborList/CommunityEdgeList'
 import { ScrollArea } from '../ScollArea'
 import { CommunityDataProvider } from '../common/dataProviders'
-import { HierarchyDataProvider } from '../common/dataProviders/HierachyDataProvider'
 import { useContainerStyle, useThemesAccentStyle } from '../hooks/theme'
 import { useAdjacentCommunityData } from '../hooks/useAdjacentCommunityData'
 import { useCommunityData } from '../hooks/useCommunityData'
@@ -22,39 +21,29 @@ import { CommunityOverview } from './CommunityOverview'
 import { CommunityTable } from './CommunityTable'
 
 export interface ICommunityCardProps {
-	community: ICommunityDetail
 	maxSize: number
 	maxLevel: number
 	level: number
-	hierachyDataProvider: HierarchyDataProvider
 	incrementLevel?: boolean // adjust from 0 to 1 based indexing on levels if needed
 	neighborsLoaded: boolean
 	neighborCallback?: ILoadNeighborCommunities
 	settings: ISettingState
+	dataProvider: CommunityDataProvider
 }
 
 const ENTITY_LOADER_MSG = 'Fetching entity data...'
 
 export const CommunityCard: React.FC<ICommunityCardProps> = memo(
 	function CommunityCard({
-		community,
 		maxSize,
 		maxLevel,
 		level,
 		incrementLevel,
 		neighborsLoaded,
-		hierachyDataProvider,
 		neighborCallback,
 		settings,
+		dataProvider,
 	}: ICommunityCardProps) {
-		/*eslint-disable react-hooks/exhaustive-deps*/
-		const dataProvider = useMemo<CommunityDataProvider>(
-			() => new CommunityDataProvider(community, hierachyDataProvider, level),
-			[
-				/* no deps intentionally */
-			],
-		)
-		/*eslint-enable react-hooks/exhaustive-deps*/
 		const {
 			isOpen: isOpenProp,
 			minimizeColumns,
@@ -63,14 +52,7 @@ export const CommunityCard: React.FC<ICommunityCardProps> = memo(
 			controls,
 		} = settings
 
-		useUpdatedCommunityProvider(
-			hierachyDataProvider,
-			dataProvider,
-			community,
-			level,
-			neighborCallback,
-		)
-		const size = useMemo(() => community.size, [community])
+		useUpdatedCommunityProvider(dataProvider, level, neighborCallback)
 
 		const [
 			entities,
@@ -80,13 +62,17 @@ export const CommunityCard: React.FC<ICommunityCardProps> = memo(
 			isOpen,
 			toggleOpen,
 			filterProps,
-		] = useCommunityData(dataProvider, isOpenProp, maxLevel, size)
+		] = useCommunityData(dataProvider, isOpenProp, maxLevel)
 
 		const [
 			adjacentCommunities,
 			isAdjacentEntitiesLoading,
 		] = useAdjacentCommunityData(dataProvider, isOpen, neighborsLoaded)
 
+		const size = useMemo(() => dataProvider.size, [dataProvider.size])
+		const neighborSize = useMemo(() => dataProvider.neighborSize, [
+			dataProvider.neighborSize,
+		])
 		const [
 			setEdgeSelection,
 			loadMoreEntities,
@@ -95,7 +81,7 @@ export const CommunityCard: React.FC<ICommunityCardProps> = memo(
 			selectedCommunityEdge,
 			clearCurrentSelection,
 		] = useEdgeSelection(dataProvider)
-		const sizePercent = useCommunitySizePercent(community, maxSize)
+		const sizePercent = useCommunitySizePercent(size, maxSize)
 		const contentStyle = useContainerStyle(isOpen, entities.length > 0)
 
 		const loadingElement = useMemo(
@@ -108,7 +94,7 @@ export const CommunityCard: React.FC<ICommunityCardProps> = memo(
 		return (
 			<div>
 				<CommunityOverview
-					community={community}
+					communityId={dataProvider.communityId}
 					onToggleOpen={toggleOpen}
 					incrementLevel={incrementLevel}
 					sizePercent={sizePercent}
@@ -117,6 +103,8 @@ export const CommunityCard: React.FC<ICommunityCardProps> = memo(
 					level={level}
 					fontStyles={fontStyles}
 					controls={controls}
+					neighborSize={neighborSize}
+					size={size}
 				/>
 				<Flex>
 					<Content style={contentStyle}>
@@ -124,7 +112,7 @@ export const CommunityCard: React.FC<ICommunityCardProps> = memo(
 							<ScrollArea loadMore={loadMore} hasMore={hasMore}>
 								<CommunityTable
 									entities={entities}
-									communityId={community.communityId}
+									communityId={dataProvider.communityId}
 									visibleColumns={visibleColumns}
 									fontStyles={fontStyles}
 									minimize={minimizeColumns}

--- a/packages/hierarchy-browser/src/CommunityCard/CommunityOverview.tsx
+++ b/packages/hierarchy-browser/src/CommunityCard/CommunityOverview.tsx
@@ -5,7 +5,7 @@
 import { IconButton, Spinner, TooltipHost, Text } from '@fluentui/react'
 import React, { memo, useCallback } from 'react'
 import styled from 'styled-components'
-import { ICommunityDetail, IControls, IEntityDetail } from '..'
+import { CommunityId, IControls, IEntityDetail } from '..'
 import { MagBar } from '../MagBar'
 import { paddingLeft } from '../common/styles'
 import { IFilterProps } from '../hooks/interfaces'
@@ -23,7 +23,8 @@ import { useControls } from '../hooks/useControls'
 import { IEntityLoadParams } from '../hooks/useLoadMoreEntitiesHandler'
 
 export interface ICommunityOverviewProps {
-	community: ICommunityDetail
+	communityId: CommunityId
+	size: number
 	sizePercent: number
 	incrementLevel?: boolean // adjust from 0 to 1 based indexing on levels if needed
 	onToggleOpen: () => void
@@ -35,12 +36,14 @@ export interface ICommunityOverviewProps {
 	level: number
 	fontStyles: ICardFontStyles
 	controls?: IControls
+	neighborSize?: number
 }
 const DEFAULT_MAGBAR_WIDTH = 120
 const SPINNER_STYLE = { marginLeft: 17 }
 export const CommunityOverview: React.FC<ICommunityOverviewProps> = memo(
 	function CommunityOverview({
-		community,
+		communityId,
+		size,
 		sizePercent,
 		incrementLevel,
 		onToggleOpen,
@@ -49,6 +52,7 @@ export const CommunityOverview: React.FC<ICommunityOverviewProps> = memo(
 		level,
 		fontStyles,
 		controls,
+		neighborSize,
 	}: ICommunityOverviewProps) {
 		const levelLabel = useCommunityLevelText(level, incrementLevel)
 		const style = useThemesStyle()
@@ -56,7 +60,7 @@ export const CommunityOverview: React.FC<ICommunityOverviewProps> = memo(
 		const { showLevel, showMembership, showFilter, showExport } = useControls(
 			controls,
 		)
-		const communityText = useCommunityText(community)
+		const communityText = useCommunityText(communityId)
 
 		const handleFilterChange = useCallback(
 			(event: React.MouseEvent<HTMLButtonElement>) => {
@@ -67,7 +71,8 @@ export const CommunityOverview: React.FC<ICommunityOverviewProps> = memo(
 		)
 
 		const [handleDownload, downloadInProgress] = useCommunityDownload(
-			community,
+			communityId,
+			size,
 			getEntityCallback,
 			level,
 		)
@@ -89,13 +94,13 @@ export const CommunityOverview: React.FC<ICommunityOverviewProps> = memo(
 							</div>
 						) : null}
 					</GridItem1>
-					{community.neighborSize && community.neighborSize > 0 ? (
+					{neighborSize && neighborSize > 0 ? (
 						<GridItem2>
 							<TooltipHost content="Number of neighboring (connected) communities.  Members of neighboring communities may be related, but are less tightly connected that those within the community.">
 								<div>
 									<Text
 										variant={fontStyles.cardOverviewSubheader}
-									>{`Neighbors: ${community.neighborSize}`}</Text>
+									>{`Neighbors: ${neighborSize}`}</Text>
 								</div>
 								<HeightSpacer />
 							</TooltipHost>
@@ -103,11 +108,11 @@ export const CommunityOverview: React.FC<ICommunityOverviewProps> = memo(
 					) : null}
 					<GridItem3>
 						<FlexySubContainer>
-							{community.size && showMembership ? (
+							{size && showMembership ? (
 								<div>
 									<div>
 										<Text variant={fontStyles.cardOverviewSubheader}>
-											Members: {community.size.toLocaleString()}
+											Members: {size.toLocaleString()}
 										</Text>
 									</div>
 									<MagBar percent={sizePercent} width={DEFAULT_MAGBAR_WIDTH} />

--- a/packages/hierarchy-browser/src/common/dataProviders/CommunityDataProvider.ts
+++ b/packages/hierarchy-browser/src/common/dataProviders/CommunityDataProvider.ts
@@ -12,7 +12,6 @@ import {
 	ILoadNeighborCommunities,
 	IHierarchyDataResponse,
 } from '../..'
-// import {  useHierarchyDataProvider } from '../../utils/utils'
 import { ENTITY_TYPE } from '../types/types'
 import { EntityDataProvider } from './EntityDataProvider'
 import { HierarchyDataProvider } from './HierachyDataProvider'
@@ -99,7 +98,7 @@ export class CommunityDataProvider {
 		this._neighborEntitiesProvider.clear()
 	}
 
-	// <--- Getters/Setters --->
+	// #region Getters/Setters
 	public get loadNeighborsCallback(): ILoadNeighborCommunities | undefined {
 		return this._loadNeighborsCallback
 	}
@@ -127,7 +126,7 @@ export class CommunityDataProvider {
 	public get communityId(): CommunityId {
 		return this._community
 	}
-	// <--- Getters/Setters --->
+	// #endregion
 	private addToNeighborCommunitiesArray(
 		communities: INeighborCommunityDetail[],
 	): void {
@@ -155,8 +154,13 @@ export class CommunityDataProvider {
 			}
 		}
 	}
-
-	// <--- Load Neighbor Community Data --->
+	// #region Load Neighbor Communities
+	/**
+	 * Fetches neighbor communities (either synchronously or async) in a given window.
+	 * @param {number} offset - offset to start array slice
+	 * @param {number} pageSize - optional number of communities to fetch, defaulted to 100.
+	 * @returns {Promise} Promise<INeighborCommunityDetail[] | undefined> returns communities if available
+	 */
 	public async getAdjacentCommunities(
 		offset: number,
 		pageSize?: number,
@@ -180,9 +184,18 @@ export class CommunityDataProvider {
 			)
 		}
 	}
-	// <--- Load Neighbor Community Data --->
-
-	// <--- Load entities from community or neighbors --->
+	// #endregion
+	// #region Load Neighbor Communities
+	/**
+	 * Fetches entites (either neighbors or community) communities (either synchronously or async) in a given window from EntityProvider.
+	 * @param {number} offset - offset to start array slice
+	 * @param {number} pageSize - optional number of communities to fetch, defaulted to 100.
+	 * @param {CommunityId} community - id of the community
+	 * @param {boolean} filtered - should result be filtered
+	 * @param {ENTITY_TYPE} entityType - type of entity (neighbor or entity), default to entity
+	 * @param {number} max - set size for neighbors on selection
+	 * @returns {Promise} Promise<IEntityDetail[]> returns entities
+	 */
 	public async getCommunityMembers(
 		offset: number,
 		pageSize?: number,
@@ -208,5 +221,5 @@ export class CommunityDataProvider {
 		}
 		return await provider.getCommunityMembers(params, max || this._size)
 	}
-	// <--- Load entities from community or neighbors --->
+	// #endregion
 }

--- a/packages/hierarchy-browser/src/common/dataProviders/CommunityDataProvider.ts
+++ b/packages/hierarchy-browser/src/common/dataProviders/CommunityDataProvider.ts
@@ -8,10 +8,11 @@ import {
 	INeighborCommunityDetail,
 	ICommunityDetail,
 	ILoadParams,
-	IHierarchyDataResponse,
 	IEntityDetail,
 	ILoadNeighborCommunities,
+	IHierarchyDataResponse,
 } from '../..'
+// import {  useHierarchyDataProvider } from '../../utils/utils'
 import { ENTITY_TYPE } from '../types/types'
 import { EntityDataProvider } from './EntityDataProvider'
 import { HierarchyDataProvider } from './HierachyDataProvider'
@@ -19,9 +20,9 @@ import { HierarchyDataProvider } from './HierachyDataProvider'
 export const DEFAULT_LOAD_COUNT = 100
 
 export class CommunityDataProvider {
-	private _loadCount = DEFAULT_LOAD_COUNT
 	private _community: CommunityId = ''
-	private _neigborCommunities: INeighborCommunityDetail[] = []
+	private _neighborSize = -1
+	private _neighborCommunities: INeighborCommunityDetail[] = []
 	private _size = 0
 	private _level = 0
 	private _filterEntitiesFlag = false
@@ -30,49 +31,12 @@ export class CommunityDataProvider {
 	private _entityProvider: EntityDataProvider
 
 	constructor(
-		communityData?: ICommunityDetail,
-		hierachyDataProvider?: HierarchyDataProvider,
-		level?: number,
-	) {
-		if (communityData) {
-			this.updateCommunityData(communityData)
-		}
-		this._level = level || -1
-		const callback =
-			hierachyDataProvider &&
-			this.useHierarchyDataProvider(hierachyDataProvider)
-		this._loadNeighborsCallback = hierachyDataProvider?.getNeighborsAtLevel
-		this._entityProvider = new EntityDataProvider(
-			ENTITY_TYPE.ENTITY,
-			this._size,
-			callback,
-		)
-		this._neighborEntitiesProvider = new EntityDataProvider(
-			ENTITY_TYPE.NEIGHBOR,
-			-1,
-			callback,
-		)
-		this.setFilterEntities(false)
-	}
-
-	public updateCommunityData(communityData: ICommunityDetail): void {
-		this._community = communityData.communityId
-		if (communityData.entityIds) {
-			this._size = communityData.entityIds.length
-		} else {
-			this._size = communityData.size || 0
-		}
-	}
-
-	public get loadNeighborsCallback(): ILoadNeighborCommunities | undefined {
-		return this._loadNeighborsCallback
-	}
-	public set loadNeighborsCallback(cb: ILoadNeighborCommunities | undefined) {
-		this._loadNeighborsCallback = cb
-	}
-	public updateHierarchyDataProvider(
+		communityData: ICommunityDetail,
 		hierachyDataProvider: HierarchyDataProvider,
-	): void {
+		level: number,
+	) {
+		this.updateCommunityData(communityData)
+		this._level = level
 		const callback = this.useHierarchyDataProvider(hierachyDataProvider)
 		this._loadNeighborsCallback = hierachyDataProvider.getNeighborsAtLevel
 		this._entityProvider = new EntityDataProvider(
@@ -82,11 +46,11 @@ export class CommunityDataProvider {
 		)
 		this._neighborEntitiesProvider = new EntityDataProvider(
 			ENTITY_TYPE.NEIGHBOR,
-			-1,
+			this._neighborSize,
 			callback,
 		)
+		this.setFilterEntities(false)
 	}
-
 	private useHierarchyDataProvider(
 		hierachyDataProvider: HierarchyDataProvider,
 	): (
@@ -98,7 +62,7 @@ export class CommunityDataProvider {
 		return getEntitiesfromProvider
 	}
 
-	public async getEntities(
+	private async getEntities(
 		hierarchyProvider: HierarchyDataProvider,
 		params: ILoadParams,
 		type?: ENTITY_TYPE,
@@ -110,6 +74,22 @@ export class CommunityDataProvider {
 		}
 	}
 
+	public updateCommunityData(communityData: ICommunityDetail): void {
+		this._community = communityData.communityId
+		this._size = communityData.entityIds?.length || communityData.size
+		this._neighborSize = communityData.neighborSize || -1
+	}
+
+	public updateHierarchyDataProvider(
+		hierachyDataProvider: HierarchyDataProvider,
+	): void {
+		const callback = this.useHierarchyDataProvider(hierachyDataProvider)
+		this._loadNeighborsCallback = hierachyDataProvider.getNeighborsAtLevel
+		this._entityProvider.size = this._size
+		this._entityProvider.loadEntitiesFromProvider = callback
+		this._neighborEntitiesProvider.loadEntitiesFromProvider = callback
+	}
+
 	public setFilterEntities(filterEntities: boolean): void {
 		this._filterEntitiesFlag = filterEntities
 		this._entityProvider.clearDisplay()
@@ -118,11 +98,26 @@ export class CommunityDataProvider {
 	public clearNeighborEdges(): void {
 		this._neighborEntitiesProvider.clear()
 	}
+
+	// <--- Getters/Setters --->
+	public get loadNeighborsCallback(): ILoadNeighborCommunities | undefined {
+		return this._loadNeighborsCallback
+	}
+	public set loadNeighborsCallback(cb: ILoadNeighborCommunities | undefined) {
+		this._loadNeighborsCallback = cb
+	}
+
 	public set level(level: number) {
 		this._level = level
 	}
 	public get level(): number {
 		return this._level
+	}
+	public set neighborSize(size: number) {
+		this._neighborSize = size
+	}
+	public get neighborSize(): number {
+		return this._neighborSize
 	}
 
 	public get size(): number {
@@ -132,16 +127,20 @@ export class CommunityDataProvider {
 	public get communityId(): CommunityId {
 		return this._community
 	}
-
+	// <--- Getters/Setters --->
 	private addToNeighborCommunitiesArray(
 		communities: INeighborCommunityDetail[],
 	): void {
-		this._neigborCommunities = this._neigborCommunities.concat(communities)
+		this._neighborCommunities = this._neighborCommunities.concat(communities)
 	}
 
 	private async loadNeighborsAsync(
 		params: ILoadParams,
 	): Promise<INeighborCommunityDetail[] | undefined> {
+		// if already init neighbors, return stored communities
+		if (this._neighborCommunities.length > 0 && params.offset === 0) {
+			return this._neighborCommunities
+		}
 		if (this._loadNeighborsCallback) {
 			const nextNeighbors = await this._loadNeighborsCallback(
 				params,
@@ -157,11 +156,13 @@ export class CommunityDataProvider {
 		}
 	}
 
+	// <--- Load Neighbor Community Data --->
 	public async getAdjacentCommunities(
 		offset: number,
 		pageSize?: number,
 	): Promise<INeighborCommunityDetail[] | undefined> {
-		const loadCount = pageSize || this._loadCount
+		const loadCount = pageSize || DEFAULT_LOAD_COUNT
+
 		const params = {
 			communityId: this._community,
 			level: this._level,
@@ -173,13 +174,15 @@ export class CommunityDataProvider {
 			const nextNeighbors = this.loadNeighborsAsync(params)
 			return nextNeighbors || []
 		} catch (err) {
-			console.log(err)
+			console.warn(err)
 			throw Error(
 				`Error: There is an issue loading neighbors for level ${this._level}, community ${this._community}`,
 			)
 		}
 	}
+	// <--- Load Neighbor Community Data --->
 
+	// <--- Load entities from community or neighbors --->
 	public async getCommunityMembers(
 		offset: number,
 		pageSize?: number,
@@ -188,7 +191,7 @@ export class CommunityDataProvider {
 		entityType?: ENTITY_TYPE,
 		max?: number,
 	): Promise<IEntityDetail[]> {
-		const loadCount = pageSize || this._loadCount
+		const loadCount = pageSize || DEFAULT_LOAD_COUNT
 		const communityId = community !== undefined ? community : this._community
 		const filteredFlag =
 			filtered !== undefined ? filtered : this._filterEntitiesFlag
@@ -205,4 +208,5 @@ export class CommunityDataProvider {
 		}
 		return await provider.getCommunityMembers(params, max || this._size)
 	}
+	// <--- Load entities from community or neighbors --->
 }

--- a/packages/hierarchy-browser/src/common/dataProviders/EntityDataProvider.ts
+++ b/packages/hierarchy-browser/src/common/dataProviders/EntityDataProvider.ts
@@ -9,7 +9,6 @@ import {
 	ILoadParams,
 	IHierarchyDataResponse,
 } from '../..'
-import { dedup } from '../../utils/utils'
 import { ENTITY_TYPE } from '../types/types'
 
 export class EntityDataProvider {
@@ -50,24 +49,22 @@ export class EntityDataProvider {
 		this.clearEntities()
 	}
 
+	// <--- Getters/Setters --->
+	public set size(s: number | undefined) {
+		this._size = s === undefined || s === -1 ? undefined : s
+	}
+	public get size(): number | undefined {
+		return this._size
+	}
+
 	private clearEntities(): void {
 		this._entities = []
 	}
 	public get entities(): IEntityDetail[] {
 		return this._entities
 	}
-	private addToEntitiesArray(
-		entities: IEntityDetail[],
-		checkDups: boolean,
-	): void {
-		const all = this._entities.concat(entities)
-		// debug if dups are present
-		// by default is false to reduce compute
-		if (checkDups) {
-			this._entities = dedup(all)
-		} else {
-			this._entities = all
-		}
+	private addToEntitiesArray(entities: IEntityDetail[]): void {
+		this._entities = this._entities.concat(entities)
 	}
 	public get displayEntities(): IEntityDetail[] {
 		return this._displayEntities
@@ -76,6 +73,16 @@ export class EntityDataProvider {
 	public set displayEntities(display: IEntityDetail[]) {
 		this._displayEntities = display
 	}
+
+	public set loadEntitiesFromProvider(
+		handleLoading: (
+			params: ILoadParams,
+			entity: ENTITY_TYPE,
+		) => Promise<IHierarchyDataResponse | undefined>,
+	) {
+		this._loadEntitiesFromProvider = handleLoading
+	}
+	// <--- Getters/Setters --->
 
 	private getFilterEntitiesFromCache(): IEntityDetail[] {
 		// get cached filtered IDS from Set
@@ -118,7 +125,7 @@ export class EntityDataProvider {
 				//store ids in map
 				this._filteredIds = new Set(data.map(d => d.id))
 			} else {
-				this.addToEntitiesArray(data, false)
+				this.addToEntitiesArray(data)
 			}
 		}
 		return data
@@ -146,6 +153,7 @@ export class EntityDataProvider {
 				}
 			}
 		} else {
+			// do we need to get more?
 			if (this._entities.length < totalLength) {
 				if (size && this._entities.length < size) {
 					await this.loadAndSaveItems(params)

--- a/packages/hierarchy-browser/src/common/dataProviders/EntityDataProvider.ts
+++ b/packages/hierarchy-browser/src/common/dataProviders/EntityDataProvider.ts
@@ -49,7 +49,7 @@ export class EntityDataProvider {
 		this.clearEntities()
 	}
 
-	// <--- Getters/Setters --->
+	// #region Getters/Setters
 	public set size(s: number | undefined) {
 		this._size = s === undefined || s === -1 ? undefined : s
 	}
@@ -82,7 +82,7 @@ export class EntityDataProvider {
 	) {
 		this._loadEntitiesFromProvider = handleLoading
 	}
-	// <--- Getters/Setters --->
+	// #endregion
 
 	private getFilterEntitiesFromCache(): IEntityDetail[] {
 		// get cached filtered IDS from Set

--- a/packages/hierarchy-browser/src/common/dataProviders/HierachyDataProvider.ts
+++ b/packages/hierarchy-browser/src/common/dataProviders/HierachyDataProvider.ts
@@ -30,13 +30,18 @@ export class HierarchyDataProvider {
 	private _neighbors: INeighborCommunityDetail[] | undefined
 	private _communities: ICommunity[] = []
 
-	// <---- update communities properties ---->
+	/**
+	 * update communities properties and saved reference in data manager
+	 * @param {ICommunityDetail[]} entities - communities parameter from API
+	 */
 	public updateCommunities(communities: ICommunityDetail[]): void {
 		this._communities = addLevelLabels(communities)
 	}
 
-	// <---- update Entities properties ---->
-	// check if async loader, data array or undefined
+	/**
+	 * check if async loader, data array or undefined
+	 * @param {IEntityDetail[] | ILoadEntitiesAsync | undefined} entities - entities parameter from API
+	 */
 	public updateEntities(entities?: IEntityDetail[] | ILoadEntitiesAsync): void {
 		if (entities) {
 			this.initEntitiesByLoadType(entities)
@@ -56,10 +61,12 @@ export class HierarchyDataProvider {
 			this._asyncEntityLoader = entities as ILoadEntitiesAsync
 		}
 	}
-	// <---- update Entities properties ---->
 
-	// <---- update Neighbors properties ---->
-	// check if async loader, data array or undefined
+	/**
+	 * check if neighbors is an async loader, data array or undefined.
+	 * @param { INeighborCommunityDetail[] | ILoadNeighborCommunitiesAsync | undefined} neighbors - neighbor parameter from API
+	 * @returns {boolean} boolean value is neighbors is loaded
+	 */
 	public updateNeighbors(
 		neighbors?: INeighborCommunityDetail[] | ILoadNeighborCommunitiesAsync,
 	): boolean {
@@ -82,9 +89,8 @@ export class HierarchyDataProvider {
 		this._asyncNeighborLoader = communities as ILoadNeighborCommunitiesAsync
 		return true
 	}
-	// <---- update Neighbors properties ---->}
 
-	// <--- Getters/Setters --->
+	// #region Getters/Setters
 	public get asyncEntityLoader(): ILoadEntitiesAsync | undefined {
 		return this._asyncEntityLoader
 	}
@@ -106,9 +112,13 @@ export class HierarchyDataProvider {
 	public set neighbors(neighbors: INeighborCommunityDetail[] | undefined) {
 		this._neighbors = neighbors
 	}
-	// <--- Getters/Setters --->
+	// #endregion
 
-	// <-- Callback to retrieve neighbor community data either async or static -->
+	/**
+	 * Callback to retrieve neighbor community data either async or static
+	 * @param {ILoadParams} params - parameters to fetch (communityId, window size, filtered, level)
+	 * @returns {Promise} Promise<IHierarchyNeighborResponse> containing neighbor communities
+	 */
 	public async getNeighborsAtLevel(
 		params: ILoadParams,
 		communityId: string,
@@ -125,7 +135,12 @@ export class HierarchyDataProvider {
 		return { data: [], error: new Error('neighbor communities not loaded') }
 	}
 
-	// <-- Retrieve static entities (either neighbor or community entities) -->
+	/**
+	 * Retrieve static entities (either neighbor or community entities)
+	 * @param {ILoadParams} params - parameters to fetch (communityId, window size, filtered, level)
+	 * @param {ENTITY_TYPE} type - type of entity (neighbor or entity)
+	 * @returns {IHierarchyDataResponse} object containing data of entities and error (if applicable)
+	 */
 	public getEntities(
 		loadParams: ILoadParams,
 		type?: ENTITY_TYPE,

--- a/packages/hierarchy-browser/src/common/types/types.ts
+++ b/packages/hierarchy-browser/src/common/types/types.ts
@@ -8,6 +8,7 @@ import {
 	INeighborCommunityDetail,
 	IEntityDetail,
 } from '../..'
+import { CommunityDataProvider } from '../dataProviders'
 
 export interface ICommunity extends ICommunityDetail {
 	level: number
@@ -23,4 +24,12 @@ export interface IEntityMap {
 export enum ENTITY_TYPE {
 	ENTITY = 'entity',
 	NEIGHBOR = 'neighbor',
+}
+
+export interface IDataProvidersCache {
+	[id: string]: CommunityDataProvider
+}
+
+export interface ICardOrder {
+	[id: string]: number
 }

--- a/packages/hierarchy-browser/src/hooks/useCommunityData.ts
+++ b/packages/hierarchy-browser/src/hooks/useCommunityData.ts
@@ -18,7 +18,6 @@ export function useCommunityData(
 	dataProvider: CommunityDataProvider,
 	isOpenProp: boolean | undefined,
 	maxLevel: number,
-	size: number,
 ): [
 	// entities
 	IEntityDetail[],
@@ -69,6 +68,8 @@ export function useCommunityData(
 		isLoading,
 		dataProvider,
 	)
+
+	const size = useMemo(() => dataProvider.size, [dataProvider.size])
 
 	useLoadEntitiesOnMountEffect(
 		loadInitialEntities,

--- a/packages/hierarchy-browser/src/hooks/useCommunityData.ts
+++ b/packages/hierarchy-browser/src/hooks/useCommunityData.ts
@@ -69,13 +69,11 @@ export function useCommunityData(
 		dataProvider,
 	)
 
-	const size = useMemo(() => dataProvider.size, [dataProvider.size])
-
 	useLoadEntitiesOnMountEffect(
 		loadInitialEntities,
 		isOpen,
 		entitiesLoaded,
-		size,
+		dataProvider.size,
 	)
 
 	const toggleOpen = useCallback(() => {

--- a/packages/hierarchy-browser/src/hooks/useCommunityDetails.ts
+++ b/packages/hierarchy-browser/src/hooks/useCommunityDetails.ts
@@ -4,7 +4,7 @@
  */
 import { max } from 'd3-array'
 import { useMemo } from 'react'
-import { ICommunityDetail } from '..'
+import { CommunityId, ICommunityDetail } from '..'
 
 export function useCommunityLevelText(
 	level: number,
@@ -34,6 +34,6 @@ export function useCommunitySizeCalculator(data: ICommunityDetail[]): number {
 	}, [data])
 }
 
-export function useCommunityText(community: ICommunityDetail): string {
-	return useMemo(() => `Community: ${community.communityId}`, [community])
+export function useCommunityText(communityId: CommunityId): string {
+	return useMemo(() => `Community: ${communityId}`, [communityId])
 }

--- a/packages/hierarchy-browser/src/hooks/useCommunityDownload.ts
+++ b/packages/hierarchy-browser/src/hooks/useCommunityDownload.ts
@@ -3,13 +3,16 @@
  * Licensed under the MIT license. See LICENSE file in the project.
  */
 import { BaseButton, Button } from '@fluentui/react'
-import { useState, useCallback } from 'react'
-import { ICommunityDetail, IEntityDetail } from '..'
+import React, { useState, useCallback } from 'react'
+
+import { IEntityDetail } from '..'
+import { CommunityId } from '../types'
 import { exportCSVFile } from '../utils/utils'
 import { IEntityLoadParams } from './useLoadMoreEntitiesHandler'
 
 export const downloadCommunityMemebers = async (
-	community: ICommunityDetail,
+	communityId: CommunityId,
+	size: number,
 	getEntityCallback: (
 		pageNumber?: number,
 		params?: IEntityLoadParams,
@@ -17,10 +20,10 @@ export const downloadCommunityMemebers = async (
 	level: number,
 ): Promise<void> => {
 	const response = await getEntityCallback(undefined, {
-		loadCount: community.size,
-		communityId: community.communityId,
+		loadCount: size,
+		communityId: communityId,
 	})
-	const filename = `c${community.communityId}_level${level}`
+	const filename = `c${communityId}_level${level}`
 	if (response) {
 		exportCSVFile(response, filename)
 	} else {
@@ -29,7 +32,8 @@ export const downloadCommunityMemebers = async (
 }
 
 export function useCommunityDownload(
-	community: ICommunityDetail,
+	communityId: CommunityId,
+	size: number,
 	getEntityCallback: (
 		pageNumber?: number,
 		params?: IEntityLoadParams,
@@ -67,7 +71,8 @@ export function useCommunityDownload(
 			setIsLoading(true)
 			console.log(`initiated download of level: ${level} community: ${level}`)
 			const promise = downloadCommunityMemebers(
-				community,
+				communityId,
+				size,
 				getEntityCallback,
 				level,
 			)
@@ -76,7 +81,7 @@ export function useCommunityDownload(
 			})
 			promise.finally(() => setIsLoading(false))
 		},
-		[community, setIsLoading, getEntityCallback, level],
+		[communityId, setIsLoading, getEntityCallback, level, size],
 	)
 
 	return [handleDownloadClick, isLoading]

--- a/packages/hierarchy-browser/src/hooks/useCommunityProvider.ts
+++ b/packages/hierarchy-browser/src/hooks/useCommunityProvider.ts
@@ -10,7 +10,7 @@ import { ICommunityDetail } from '../types/types'
 
 interface ICommunityProviderHook {
 	communities: ICommunityDetail[]
-	setProviderCache: (cache: any) => void
+	setProviderCache: (cache: IDataProvidersCache) => void
 	hierachyDataProvider: HierarchyDataProvider
 	setCardOrder: (sorted: ICardOrder) => void
 }
@@ -25,7 +25,7 @@ export const useCommunityProvider = ({
 }: ICommunityProviderHook): void => {
 	useMemo(() => {
 		const reverseList = [...communities].reverse()
-		setProviderCache(cache => {
+		setProviderCache((cache: IDataProvidersCache) => {
 			const communityIds = reverseList.map(c => c.communityId)
 			const cacheIds = Object.keys(cache)
 			const intersection = cacheIds.filter(value =>

--- a/packages/hierarchy-browser/src/hooks/useCommunityProvider.ts
+++ b/packages/hierarchy-browser/src/hooks/useCommunityProvider.ts
@@ -1,0 +1,59 @@
+/*!
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project.
+ */
+import { useMemo } from 'react'
+import { CommunityDataProvider } from '../common/dataProviders'
+import { HierarchyDataProvider } from '../common/dataProviders/HierachyDataProvider'
+import { ICardOrder, IDataProvidersCache } from '../common/types/types'
+import { ICommunityDetail } from '../types/types'
+
+interface ICommunityProviderHook {
+	communities: ICommunityDetail[]
+	setProviderCache: (cache: any) => void
+	hierachyDataProvider: HierarchyDataProvider
+	setCardOrder: (sorted: ICardOrder) => void
+}
+
+// Update and add to cache of communityProviders so when new community cards are added
+// communityDataProvider is not removed
+export const useCommunityProvider = ({
+	communities,
+	setProviderCache,
+	hierachyDataProvider,
+	setCardOrder,
+}: ICommunityProviderHook): void => {
+	useMemo(() => {
+		const reverseList = [...communities].reverse()
+		setProviderCache(cache => {
+			const communityIds = reverseList.map(c => c.communityId)
+			const cacheIds = Object.keys(cache)
+			const intersection = cacheIds.filter(value =>
+				communityIds.includes(value),
+			)
+			return reverseList.reduce((acc, community, index) => {
+				if (!cache[community.communityId]) {
+					const provider = new CommunityDataProvider(
+						community,
+						hierachyDataProvider,
+						index,
+					)
+					acc[community.communityId] = provider
+					// check if its removed
+				} else if (intersection.includes(community.communityId)) {
+					const provider = cache[community.communityId]
+					provider.updateCommunityData(community)
+					provider.updateHierarchyDataProvider(hierachyDataProvider)
+					acc[community.communityId] = provider
+				}
+				return acc
+			}, {} as IDataProvidersCache)
+		})
+		const sortOrder = communities.reduce((acc, c, index) => {
+			const id = c.communityId
+			acc[id] = index
+			return acc
+		}, {} as ICardOrder)
+		setCardOrder(sortOrder)
+	}, [communities, hierachyDataProvider, setProviderCache, setCardOrder])
+}

--- a/packages/hierarchy-browser/src/hooks/useCommunityProvider.ts
+++ b/packages/hierarchy-browser/src/hooks/useCommunityProvider.ts
@@ -7,10 +7,15 @@ import { CommunityDataProvider } from '../common/dataProviders'
 import { HierarchyDataProvider } from '../common/dataProviders/HierachyDataProvider'
 import { ICardOrder, IDataProvidersCache } from '../common/types/types'
 import { ICommunityDetail } from '../types/types'
+export { IDataProvidersCache, ICardOrder } from '../common/types/types'
+
+interface SetCache {
+	(state: IDataProvidersCache): IDataProvidersCache
+}
 
 interface ICommunityProviderHook {
 	communities: ICommunityDetail[]
-	setProviderCache: (cache: IDataProvidersCache) => void
+	setProviderCache: (state: SetCache) => void
 	hierachyDataProvider: HierarchyDataProvider
 	setCardOrder: (sorted: ICardOrder) => void
 }
@@ -31,23 +36,26 @@ export const useCommunityProvider = ({
 			const intersection = cacheIds.filter(value =>
 				communityIds.includes(value),
 			)
-			return reverseList.reduce((acc, community, index) => {
-				if (!cache[community.communityId]) {
-					const provider = new CommunityDataProvider(
-						community,
-						hierachyDataProvider,
-						index,
-					)
-					acc[community.communityId] = provider
-					// check if its removed
-				} else if (intersection.includes(community.communityId)) {
-					const provider = cache[community.communityId]
-					provider.updateCommunityData(community)
-					provider.updateHierarchyDataProvider(hierachyDataProvider)
-					acc[community.communityId] = provider
-				}
-				return acc
-			}, {} as IDataProvidersCache)
+			return reverseList.reduce(
+				(acc, community, index): IDataProvidersCache => {
+					if (!cache[community.communityId]) {
+						const provider = new CommunityDataProvider(
+							community,
+							hierachyDataProvider,
+							index,
+						)
+						acc[community.communityId] = provider
+						// check if its removed
+					} else if (intersection.includes(community.communityId)) {
+						const provider = cache[community.communityId]
+						provider.updateCommunityData(community)
+						provider.updateHierarchyDataProvider(hierachyDataProvider)
+						acc[community.communityId] = provider
+					}
+					return acc
+				},
+				{} as IDataProvidersCache,
+			)
 		})
 		const sortOrder = communities.reduce((acc, c, index) => {
 			const id = c.communityId

--- a/packages/hierarchy-browser/src/hooks/useCommunitySizePercent.ts
+++ b/packages/hierarchy-browser/src/hooks/useCommunitySizePercent.ts
@@ -3,11 +3,7 @@
  * Licensed under the MIT license. See LICENSE file in the project.
  */
 import { useMemo } from 'react'
-import { ICommunityDetail } from '..'
 
-export function useCommunitySizePercent(
-	community: ICommunityDetail,
-	maxSize: number,
-): number {
-	return useMemo(() => community.size / maxSize, [community, maxSize])
+export function useCommunitySizePercent(size: number, maxSize: number): number {
+	return useMemo(() => size / maxSize, [size, maxSize])
 }

--- a/packages/hierarchy-browser/src/hooks/useUpdatedCommunityProvider.ts
+++ b/packages/hierarchy-browser/src/hooks/useUpdatedCommunityProvider.ts
@@ -4,21 +4,13 @@
  */
 import { useMemo, useEffect } from 'react'
 import { CommunityDataProvider } from '../common/dataProviders'
-import { HierarchyDataProvider } from '../common/dataProviders/HierachyDataProvider'
-import { ICommunityDetail, ILoadNeighborCommunities } from '../types'
+import { ILoadNeighborCommunities } from '../types'
 
 export function useUpdatedCommunityProvider(
-	hierachyDataProvider: HierarchyDataProvider,
 	dataProvider: CommunityDataProvider,
-	community: ICommunityDetail,
 	level: number,
 	neighborCallback?: ILoadNeighborCommunities,
 ): void {
-	useEffect(() => {
-		dataProvider.updateCommunityData(community)
-		dataProvider.updateHierarchyDataProvider(hierachyDataProvider)
-	}, [community, hierachyDataProvider, dataProvider])
-
 	useEffect(() => {
 		dataProvider.loadNeighborsCallback = neighborCallback
 	}, [neighborCallback, dataProvider])

--- a/packages/hierarchy-browser/src/utils/utils.ts
+++ b/packages/hierarchy-browser/src/utils/utils.ts
@@ -157,6 +157,11 @@ export function createEntityMap(
 	}
 }
 
+/**
+ * Determines if entities have an async callback (neighbors or community).
+ * @param entities - Entity callback or array (nieghbors  or entities) given by exposed API
+ * @returns {boolean} boolean value determining if async.
+ */
 export function isEntitiesAsync(
 	entities?:
 		| (IEntityDetail[] | INeighborCommunityDetail[])
@@ -169,9 +174,7 @@ export function isEntitiesAsync(
 
 export function addLevelLabels(communities: ICommunityDetail[]): ICommunity[] {
 	const max = communities.length - 1
-	return communities.map((comm, index) =>
-		Object.assign({}, { ...comm, level: max - index }),
-	)
+	return communities.map((comm, index) => ({ ...comm, level: max - index }))
 }
 
 export interface IColorRGB {

--- a/packages/hierarchy-browser/src/utils/utils.ts
+++ b/packages/hierarchy-browser/src/utils/utils.ts
@@ -8,6 +8,10 @@ import {
 	IEntityDetail,
 	CommunityId,
 	INeighborCommunityDetail,
+	IHierarchyDataResponse,
+	IHierarchyNeighborResponse,
+	ILoadParams,
+	ICommunityDetail,
 } from '..'
 import { ICommunity, IEntityMap } from '../common/types/types'
 
@@ -139,6 +143,35 @@ export function getStaticNeighborEntities(
 		}
 		return acc
 	}, [] as IEntityDetail[])
+}
+
+export function createEntityMap(
+	entities?: IEntityDetail[],
+): IEntityMap | undefined {
+	if (entities) {
+		return entities.reduce((acc, entity) => {
+			const id = entity.id
+			acc[id] = entity
+			return acc
+		}, {} as IEntityMap)
+	}
+}
+
+export function isEntitiesAsync(
+	entities?:
+		| (IEntityDetail[] | INeighborCommunityDetail[])
+		| ((
+				params: ILoadParams,
+		  ) => Promise<IHierarchyNeighborResponse | IHierarchyDataResponse>),
+): boolean {
+	return !Array.isArray(entities) || entities instanceof Promise
+}
+
+export function addLevelLabels(communities: ICommunityDetail[]): ICommunity[] {
+	const max = communities.length - 1
+	return communities.map((comm, index) =>
+		Object.assign({}, { ...comm, level: max - index }),
+	)
 }
 
 export interface IColorRGB {


### PR DESCRIPTION
- Add CommunityProvider cache so when new communities are added, if the community still exists in the browser, it does not recreate a new instance on the data provider. This allows to keep cache data. 

- Also, when the Hierarchy data provider updated, it would recreate entity data providers and it lost all the cached data. In this PR, on HierarchyDataProvider update, the entityProviders update reference for entity callback. 

- Minor organization and clean up changes to prep for new data management (arquero). 