### PR TITLE
feat: add expansion state and fix svg sizing for neighbors

### DIFF
--- a/.yarn/versions/0fe3b60e.yml
+++ b/.yarn/versions/0fe3b60e.yml
@@ -1,0 +1,5 @@
+releases:
+  "@essex-js-toolkit/hierarchy-browser": patch
+
+declined:
+  - "@essex-js-toolkit/dev"

--- a/packages/hierarchy-browser/src/CommunityCard/CommunityCard.tsx
+++ b/packages/hierarchy-browser/src/CommunityCard/CommunityCard.tsx
@@ -15,10 +15,12 @@ import { useAdjacentCommunityData } from '../hooks/useAdjacentCommunityData'
 import { useCommunityData } from '../hooks/useCommunityData'
 import { useCommunitySizePercent } from '../hooks/useCommunitySizePercent'
 import { useEdgeSelection } from '../hooks/useEdgeSelection'
+import { useExpandedPanel } from '../hooks/useExpandedPanel'
 import { ISettingState } from '../hooks/useSettings'
 import { useUpdatedCommunityProvider } from '../hooks/useUpdatedCommunityProvider'
 import { CommunityOverview } from './CommunityOverview'
 import { CommunityTable } from './CommunityTable'
+import { TableExpander } from './TableExpander'
 
 export interface ICommunityCardProps {
 	maxSize: number
@@ -87,6 +89,15 @@ export const CommunityCard: React.FC<ICommunityCardProps> = memo(
 
 		const colorStyle = useThemesAccentStyle(isOpen)
 
+		const {
+			edgeContentStyle,
+			edgeEntitiesContentStyle,
+			edgeEntitiesExpanderClick,
+			edgeExpanderClick,
+			edgeListOpen,
+			edgeEntitiesOpen,
+		} = useExpandedPanel({ isOpen, entities })
+
 		return (
 			<div>
 				<CommunityOverview
@@ -122,37 +133,58 @@ export const CommunityCard: React.FC<ICommunityCardProps> = memo(
 							isLoading={isLoading}
 						/>
 					</Content>
-					<Spacer style={colorStyle}></Spacer>
+
 					{adjacentCommunities && adjacentCommunities.length > 0 ? (
-						<Content style={contentStyle}>
-							<CommunityEdgeList
-								edges={adjacentCommunities}
-								selectedEdge={selectedCommunityEdge}
-								onEdgeClick={setEdgeSelection}
-								clearCurrentSelection={clearCurrentSelection}
-							/>
-						</Content>
+						<>
+							<Spacer style={colorStyle}>
+								{isOpen ? (
+									<TableExpander
+										isOpen={edgeListOpen}
+										handleButtonClick={edgeExpanderClick}
+									/>
+								) : null}
+							</Spacer>
+							<Content style={edgeContentStyle}>
+								<CommunityEdgeList
+									edges={adjacentCommunities}
+									selectedEdge={selectedCommunityEdge}
+									onEdgeClick={setEdgeSelection}
+									clearCurrentSelection={clearCurrentSelection}
+									isOpen={edgeListOpen}
+								/>
+							</Content>
+						</>
 					) : null}
 					{isAdjacentEntitiesLoading || edgeEntities?.length > 0 ? (
-						<Content style={contentStyle}>
-							{edgeEntities?.length > 0 ? (
-								<ScrollArea
-									loadMore={loadMoreEntities}
-									hasMore={moreEntitiesToLoad}
-								>
-									<CommunityTable
-										entities={edgeEntities}
-										communityId={selectedCommunityEdge?.communityId}
-										visibleColumns={visibleColumns}
-										fontStyles={fontStyles}
-										minimize={minimizeColumns}
+						<>
+							<Spacer style={colorStyle}>
+								{isOpen ? (
+									<TableExpander
+										isOpen={edgeEntitiesOpen}
+										handleButtonClick={edgeEntitiesExpanderClick}
 									/>
-								</ScrollArea>
-							) : null}
-							{isAdjacentEntitiesLoading ? (
-								<Spinner label={ENTITY_LOADER_MSG} />
-							) : null}
-						</Content>
+								) : null}
+							</Spacer>
+							<Content style={edgeEntitiesContentStyle}>
+								{edgeEntities?.length > 0 && edgeEntitiesOpen ? (
+									<ScrollArea
+										loadMore={loadMoreEntities}
+										hasMore={moreEntitiesToLoad}
+									>
+										<CommunityTable
+											entities={edgeEntities}
+											communityId={selectedCommunityEdge?.communityId}
+											visibleColumns={visibleColumns}
+											fontStyles={fontStyles}
+											minimize={minimizeColumns}
+										/>
+									</ScrollArea>
+								) : null}
+								{isAdjacentEntitiesLoading ? (
+									<Spinner label={ENTITY_LOADER_MSG} />
+								) : null}
+							</Content>
+						</>
 					) : null}
 				</Flex>
 			</div>
@@ -167,10 +199,9 @@ const Flex = styled.div`
 const Content = styled.div`
 	overflow-y: auto;
 	transition: height 0.2s;
-	flex: 1;
 `
 const Spacer = styled.div`
-	width: 10px;
 	border-style: solid;
 	border-width: 0px 0.5px 0px 0.5px;
+	align-self: center;
 `

--- a/packages/hierarchy-browser/src/CommunityCard/TableExpander.tsx
+++ b/packages/hierarchy-browser/src/CommunityCard/TableExpander.tsx
@@ -1,0 +1,44 @@
+/*!
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project.
+ */
+import { IconButton } from '@fluentui/react'
+import React, { memo, useMemo, useCallback } from 'react'
+import styled from 'styled-components'
+
+interface ITableExpander {
+	isOpen: boolean
+	handleButtonClick: (state: boolean) => void
+}
+export const TableExpander: React.FC<ITableExpander> = memo(
+	function TableExpander({ isOpen, handleButtonClick }) {
+		const iconName = useMemo(
+			() => (isOpen ? 'DoubleChevronRight12' : 'DoubleChevronLeft12'),
+			[isOpen],
+		)
+
+		const handleClick = useCallback(() => {
+			handleButtonClick(!isOpen)
+		}, [handleButtonClick, isOpen])
+		return (
+			<>
+				<Header>
+					<IconButton
+						styles={{ root: { maxHeight: '15px', maxWidth: '15px' } }}
+						iconProps={{
+							iconName,
+						}}
+						text="Panel Resize"
+						onClick={handleClick}
+					/>
+				</Header>
+			</>
+		)
+	},
+)
+
+const Header = styled.div`
+	display: flex;
+	justify-content: center;
+	align-items: center;
+`

--- a/packages/hierarchy-browser/src/NeighborList/Bar.tsx
+++ b/packages/hierarchy-browser/src/NeighborList/Bar.tsx
@@ -23,7 +23,11 @@ export const Bar: React.FC<ICellComponentProps> = memo(function Bar({
 	const size = scale(value)
 	return (
 		<>
-			<svg width={width} height={height}>
+			<svg
+				width={width}
+				height={height}
+				style={{ position: 'absolute', top: 0, left: 0 }}
+			>
 				<rect
 					width={size || 10}
 					height={height}

--- a/packages/hierarchy-browser/src/NeighborList/CommunityEdgeList.tsx
+++ b/packages/hierarchy-browser/src/NeighborList/CommunityEdgeList.tsx
@@ -4,7 +4,7 @@
  */
 import { Text } from '@fluentui/react'
 import { useThematic } from '@thematic/react'
-import React, { useCallback, memo, useRef, useMemo } from 'react'
+import React, { useCallback, memo, useRef } from 'react'
 import styled from 'styled-components'
 import { INeighborCommunityDetail } from '..'
 import {
@@ -25,6 +25,7 @@ export interface ICommunityEdgeListProps {
 	onEdgeClick: (edge?: INeighborCommunityDetail) => Promise<void>
 	clearCurrentSelection: () => Promise<void>
 	selectedEdge?: INeighborCommunityDetail
+	isOpen: boolean
 }
 const CommunityEdgeList: React.FC<ICommunityEdgeListProps> = memo(
 	function CommunityEdgeList({
@@ -52,17 +53,15 @@ const CommunityEdgeList: React.FC<ICommunityEdgeListProps> = memo(
 		)
 		const sortedEdges = useSortedNeighbors(edges)
 		const ref = useRef(null)
-		const dimensions = useDimensions(ref)
+		const connRef = useRef(null)
+		const memberDimensions = useDimensions(ref)
+		const connectionDimensions = useDimensions(connRef)
 		const [getBackgroundStyle, barColor, connScale, sizeScale] = useRowElements(
 			theme,
 			selectedEdge,
 			edges,
-			dimensions,
+			memberDimensions,
 		)
-
-		const width = useMemo(() => (dimensions ? dimensions.width : 10), [
-			dimensions,
-		])
 
 		return sortedEdges ? (
 			<Table>
@@ -106,7 +105,7 @@ const CommunityEdgeList: React.FC<ICommunityEdgeListProps> = memo(
 									}}
 									key={`neighbor-community-${0}`}
 									onClick={() => handleEdgeClick(edge)}
-									ref={ref}
+									ref={connRef}
 								>
 									<div>
 										<AbsoluteDiv>
@@ -115,13 +114,15 @@ const CommunityEdgeList: React.FC<ICommunityEdgeListProps> = memo(
 													{edge.connections}
 												</Text>
 											</TextContainer>
-											<Bar
-												value={edge.connections}
-												width={width}
-												height={25}
-												color={barColor}
-												scale={connScale}
-											/>
+											{connectionDimensions?.width ? (
+												<Bar
+													value={edge.connections}
+													width={connectionDimensions.width}
+													height={connectionDimensions?.height || 25}
+													color={barColor}
+													scale={connScale}
+												/>
+											) : null}
 										</AbsoluteDiv>
 									</div>
 								</TableCell>
@@ -131,24 +132,25 @@ const CommunityEdgeList: React.FC<ICommunityEdgeListProps> = memo(
 									}}
 									key={`neighbor-community-${1}`}
 									onClick={() => handleEdgeClick(edge)}
+									ref={ref}
 								>
-									<div>
-										<AbsoluteDiv>
-											<TextContainer>
-												<Text variant={tableItems} styles={textStyle}>
-													{edge.size}
-												</Text>
-											</TextContainer>
+									<AbsoluteDiv>
+										<TextContainer>
+											<Text variant={tableItems} styles={textStyle}>
+												{edge.size}
+											</Text>
+										</TextContainer>
 
+										{memberDimensions?.width ? (
 											<Bar
 												value={edge.size}
-												width={width}
-												height={25}
+												width={memberDimensions.width}
+												height={memberDimensions?.height || 25}
 												color={barColor}
 												scale={sizeScale}
 											/>
-										</AbsoluteDiv>
-									</div>
+										) : null}
+									</AbsoluteDiv>
 								</TableCell>
 							</tr>
 						)
@@ -182,11 +184,11 @@ const TableCell = styled.td`
 `
 const TextContainer = styled.div`
 	z-index: 2;
-	left: -10;
-	width: 100%;
+	top: 0px;
+	right: 5px;
+	/* left: -10; */
 	position: absolute;
 `
 const AbsoluteDiv = styled.div`
-	position: absolute;
 	top: 0;
 `

--- a/packages/hierarchy-browser/src/common/types/index.ts
+++ b/packages/hierarchy-browser/src/common/types/index.ts
@@ -1,0 +1,5 @@
+/*!
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project.
+ */
+export * from './types'

--- a/packages/hierarchy-browser/src/hooks/theme.ts
+++ b/packages/hierarchy-browser/src/hooks/theme.ts
@@ -22,7 +22,10 @@ export function useContainerStyle(
 		() =>
 			({
 				height: isOpen ? (entitiesAvailable ? 250 : 75) : 0,
+				width: isOpen ? '100%' : '0px',
 				border: `1px solid ${theme.application().faint().hex()}`,
+				flex: isOpen ? 1 : 'revert',
+				WebkitFlex: isOpen ? 1 : 'revert',
 			} as React.CSSProperties),
 		[isOpen, theme, entitiesAvailable],
 	)
@@ -46,6 +49,7 @@ export function useThemesAccentStyle(isOpen: boolean): React.CSSProperties {
 			background: theme.application().faint().hex(),
 			borderColor: theme.application().lowContrast().hex(),
 			visible: isOpen ? 'visible' : 'hidden',
+			width: isOpen ? '15px' : 0,
 		}),
 		[theme, isOpen],
 	)

--- a/packages/hierarchy-browser/src/hooks/useCommunityProvider.ts
+++ b/packages/hierarchy-browser/src/hooks/useCommunityProvider.ts
@@ -7,7 +7,6 @@ import { CommunityDataProvider } from '../common/dataProviders'
 import { HierarchyDataProvider } from '../common/dataProviders/HierachyDataProvider'
 import { ICardOrder, IDataProvidersCache } from '../common/types/types'
 import { ICommunityDetail } from '../types/types'
-export { IDataProvidersCache, ICardOrder } from '../common/types/types'
 
 interface SetCache {
 	(state: IDataProvidersCache): IDataProvidersCache

--- a/packages/hierarchy-browser/src/hooks/useExpandedPanel.ts
+++ b/packages/hierarchy-browser/src/hooks/useExpandedPanel.ts
@@ -1,0 +1,60 @@
+/*!
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project.
+ */
+import { useState, useCallback } from 'react'
+import { IEntityDetail } from '..'
+import { useContainerStyle } from './theme'
+
+interface IEdgePanelHook {
+	isOpen: boolean
+	entities: IEntityDetail[]
+}
+
+interface IEdgeState {
+	edgeContentStyle: React.CSSProperties
+	edgeEntitiesContentStyle: React.CSSProperties
+	edgeEntitiesExpanderClick: (newState: boolean) => void
+	edgeExpanderClick: (newState: boolean) => void
+	edgeListOpen: boolean
+	edgeEntitiesOpen: boolean
+}
+
+// Controls panel expansion state for neighbor communities and selected neighbor entities
+export function useExpandedPanel({
+	isOpen,
+	entities,
+}: IEdgePanelHook): IEdgeState {
+	const [edgeListOpen, setEdgeListOpen] = useState<boolean>(true)
+	const [edgeEntitiesOpen, setEdgeEntitiesOpen] = useState<boolean>(true)
+	const edgeContentStyle = useContainerStyle(
+		isOpen && edgeListOpen,
+		entities.length > 0,
+	)
+	const edgeEntitiesExpanderClick = useCallback(
+		(newState: boolean) => {
+			setEdgeEntitiesOpen(newState)
+		},
+		[setEdgeEntitiesOpen],
+	)
+
+	const edgeExpanderClick = useCallback(
+		(newState: boolean) => {
+			setEdgeListOpen(newState)
+		},
+		[setEdgeListOpen],
+	)
+
+	const edgeEntitiesContentStyle = useContainerStyle(
+		isOpen && edgeEntitiesOpen,
+		entities.length > 0,
+	)
+	return {
+		edgeContentStyle,
+		edgeEntitiesContentStyle,
+		edgeEntitiesExpanderClick,
+		edgeExpanderClick,
+		edgeListOpen,
+		edgeEntitiesOpen,
+	}
+}


### PR DESCRIPTION
Address issue #32 , allowing neighbors and selected neighbor communities to expand or collapse on click. The logic for the panel state is contained in _useExpandedPanel.ts_  and implemented on styled component _Spacer_ .

This PR also address the issue of SVG sizing for neighbors panel. Originally the sizing for neighbors and connections were based on a single table row ref, which is incorrect, and this fixes it by getting dimensions for each column individually. 