### PR TITLE
chore: upgrade yarn versions for hierarchy-browser

### DIFF
--- a/.yarn/versions/78340378.yml
+++ b/.yarn/versions/78340378.yml
@@ -1,6 +1,0 @@
-releases:
-  "@essex-js-toolkit/hierarchy-browser": patch
-
-declined:
-  - "@essex-js-toolkit/dev"
-  - "@essex-js-toolkit/thematic-lineup"

--- a/packages/hierarchy-browser/package.json
+++ b/packages/hierarchy-browser/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@essex-js-toolkit/hierarchy-browser",
-	"version": "2.0.4",
+	"version": "2.0.5",
 	"description": "React component to display hierarchical community data",
 	"license": "MIT",
 	"main": "src/index.ts",


### PR DESCRIPTION
upgrade Hierarchy Browser release version from 2.0.4 to 2.0.5