### PR TITLE
Fix/hierarchy browser asyncloading

### DIFF
--- a/.yarn/versions/78340378.yml
+++ b/.yarn/versions/78340378.yml
@@ -1,0 +1,5 @@
+releases:
+  "@essex-js-toolkit/hierarchy-browser": minor
+
+declined:
+  - "@essex-js-toolkit/dev"

--- a/.yarn/versions/78340378.yml
+++ b/.yarn/versions/78340378.yml
@@ -1,6 +1,0 @@
-releases:
-  "@essex-js-toolkit/hierarchy-browser": patch
-
-declined:
-  - "@essex-js-toolkit/dev"
-  - "@essex-js-toolkit/thematic-lineup"

--- a/packages/hierarchy-browser/package.json
+++ b/packages/hierarchy-browser/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@essex-js-toolkit/hierarchy-browser",
-	"version": "2.0.4",
+	"version": "2.0.5",
 	"description": "React component to display hierarchical community data",
 	"license": "MIT",
 	"main": "src/index.ts",

--- a/packages/hierarchy-browser/src/common/dataProviders/CommunityDataProvider.ts
+++ b/packages/hierarchy-browser/src/common/dataProviders/CommunityDataProvider.ts
@@ -37,7 +37,6 @@ export class CommunityDataProvider {
 		this.updateCommunityData(communityData)
 		this._level = level
 		const callback = this.useHierarchyDataProvider(hierachyDataProvider)
-		this._loadNeighborsCallback = hierachyDataProvider.getNeighborsAtLevel
 		this._entityProvider = new EntityDataProvider(
 			ENTITY_TYPE.ENTITY,
 			this._size,
@@ -83,7 +82,7 @@ export class CommunityDataProvider {
 		hierachyDataProvider: HierarchyDataProvider,
 	): void {
 		const callback = this.useHierarchyDataProvider(hierachyDataProvider)
-		this._loadNeighborsCallback = hierachyDataProvider.getNeighborsAtLevel
+		// this._loadNeighborsCallback = hierachyDataProvider.getNeighborsAtLevel
 		this._entityProvider.size = this._size
 		this._entityProvider.loadEntitiesFromProvider = callback
 		this._neighborEntitiesProvider.loadEntitiesFromProvider = callback

--- a/packages/hierarchy-browser/src/hooks/useUpdatedHierarchyProvider.ts
+++ b/packages/hierarchy-browser/src/hooks/useUpdatedHierarchyProvider.ts
@@ -14,6 +14,7 @@ import {
 	ILoadParams,
 	INeighborCommunityDetail,
 } from '../types'
+import { isEntitiesAsync } from '../utils/utils'
 export function useUpdatedHierarchyProvider(
 	communities: ICommunityDetail[],
 	hierachyDataProvider: HierarchyDataProvider,
@@ -35,7 +36,12 @@ export function useUpdatedHierarchyProvider(
 	}, [entities, hierachyDataProvider])
 
 	useEffect(() => {
-		const isLoaded = hierachyDataProvider.updateNeighbors(neighbors)
+		let isLoaded = false
+		if (neighbors) {
+			const isAsync = isEntitiesAsync(neighbors)
+			isLoaded = isAsync || neighbors.length > 0
+		}
+		hierachyDataProvider.neighbors = neighbors as INeighborCommunityDetail[]
 		setIsNeighborsLoaded(isLoaded) // trigger neighbor refresh
 	}, [neighbors, hierachyDataProvider])
 
@@ -44,9 +50,13 @@ export function useUpdatedHierarchyProvider(
 			params: ILoadParams,
 			communityId: CommunityId,
 		): Promise<IHierarchyNeighborResponse> => {
-			return await hierachyDataProvider.getNeighborsAtLevel(params, communityId)
+			return await hierachyDataProvider.getNeighborsAtLevel(
+				params,
+				communityId,
+				neighbors,
+			)
 		},
-		[hierachyDataProvider],
+		[hierachyDataProvider, neighbors],
 	)
 	return [isNeighborsLoaded, neighborCallback]
 }


### PR DESCRIPTION
Remove asyncLoader as a class property on hierarchyDataProvider and instead check if async in neighbor callback. This fixes bug where loader does not exist on update.