### PR TITLE
Fix/hierarchy browser entity styles

### DIFF
--- a/.yarn/versions/6a8929b6.yml
+++ b/.yarn/versions/6a8929b6.yml
@@ -1,0 +1,6 @@
+releases:
+  "@essex-js-toolkit/hierarchy-browser": patch
+
+declined:
+  - "@essex-js-toolkit/dev"
+  - "@essex-js-toolkit/themed-components-stories"

--- a/packages/hierarchy-browser/src/EntityItem/EntityItem.tsx
+++ b/packages/hierarchy-browser/src/EntityItem/EntityItem.tsx
@@ -8,6 +8,7 @@ import styled from 'styled-components'
 import { IEntityDetail, ITableSettings } from '..'
 import { textStyle, tableItems } from '../common/styles'
 import { useRowStyle } from './hooks/useRowStyle'
+const NO_STYLE: React.CSSProperties = Object.freeze({})
 
 export interface IEntityItemProps {
 	item: IEntityDetail
@@ -18,13 +19,8 @@ export interface IEntityItemProps {
 export const EntityItem: React.FC<IEntityItemProps> = memo(
 	({ item, attrs, index, styles }: IEntityItemProps) => {
 		const rowStyle = useRowStyle(index)
-		const itemStyle = useMemo(
-			(): React.CSSProperties => styles?.tableItems || {},
-			[styles],
-		)
-		const itemVariant = useMemo(() => styles?.tableItemsText || tableItems, [
-			styles,
-		])
+		const itemStyle = styles?.tableItems ?? NO_STYLE
+		const itemVariant = styles?.tableItemsText ?? tableItems
 
 		return (
 			<TableRow key={`e${index}`} style={rowStyle}>
@@ -41,7 +37,7 @@ export const EntityItem: React.FC<IEntityItemProps> = memo(
 								style={itemStyle}
 							>
 								{item.attrs && item.attrs[attr] ? (
-									<Text variant={tableItems} styles={textStyle}>
+									<Text variant={itemVariant} styles={textStyle}>
 										{item.attrs[attr].toLocaleString()}
 									</Text>
 								) : (

--- a/packages/hierarchy-browser/src/NeighborList/CommunityEdgeList.tsx
+++ b/packages/hierarchy-browser/src/NeighborList/CommunityEdgeList.tsx
@@ -4,15 +4,11 @@
  */
 import { Text } from '@fluentui/react'
 import { useThematic } from '@thematic/react'
-import React, { useCallback, memo, useRef, useMemo } from 'react'
+import React, { useCallback, memo, useRef } from 'react'
 import styled from 'styled-components'
 import { INeighborCommunityDetail, ITableSettings } from '..'
-import {
-	rowSubHeader,
-	rowHeader,
-	tableItems,
-	textStyle,
-} from '../common/styles'
+import { textStyle } from '../common/styles'
+import { useTableStyles } from '../hooks/useStyles'
 import { Bar } from './Bar'
 import { useRowElements } from './hooks/useRowsElements'
 import { useSortedNeighbors } from './hooks/useSortedNeighbors'
@@ -36,31 +32,15 @@ const CommunityEdgeList: React.FC<ICommunityEdgeListProps> = memo(
 		clearCurrentSelection,
 		styles,
 	}: ICommunityEdgeListProps) {
-		const headerStyle = useMemo(
-			(): React.CSSProperties => styles?.header || {},
-			[styles],
-		)
-		const subheaderStyle = useMemo(
-			(): React.CSSProperties => styles?.subheader || {},
-			[styles],
-		)
-		const rootStyle = useMemo((): React.CSSProperties => styles?.root || {}, [
-			styles,
-		])
-		const itemStyle = useMemo(
-			(): React.CSSProperties => styles?.tableItems || {},
-			[styles],
-		)
-		const headerVariant = useMemo(() => styles?.headerText || rowHeader, [
-			styles,
-		])
-		const subheaderVariant = useMemo(
-			() => styles?.subHeaderText || rowSubHeader,
-			[styles],
-		)
-		const itemVariant = useMemo(() => styles?.tableItemsText || tableItems, [
-			styles,
-		])
+		const [
+			headerVariant,
+			subheaderVariant,
+			headerStyle,
+			subheaderStyle,
+			rootStyle,
+			itemStyle,
+			itemVariant,
+		] = useTableStyles(styles)
 
 		const theme = useThematic()
 		const handleEdgeClick = useCallback(

--- a/packages/hierarchy-browser/src/hooks/useStyles.ts
+++ b/packages/hierarchy-browser/src/hooks/useStyles.ts
@@ -5,7 +5,7 @@
 import { ITextProps, IButtonStyles } from '@fluentui/react'
 import React from 'react'
 import { ICardOverviewSettings } from '..'
-import { headerLabel, subHeaderLabel } from '../common/styles'
+import { headerLabel, subHeaderLabel, tableItems } from '../common/styles'
 import { ITableSettings } from '../types'
 
 const NO_STYLE: React.CSSProperties = Object.freeze({})
@@ -56,6 +56,10 @@ export function useTableStyles(
 	React.CSSProperties,
 	//rootStyle
 	React.CSSProperties,
+	//itemStyle
+	React.CSSProperties,
+	//tableITemsText
+	ITextProps['variant'],
 ] {
 	const headerStyle = styles?.header ?? NO_STYLE
 
@@ -65,6 +69,8 @@ export function useTableStyles(
 
 	const headerVariant = styles?.headerText ?? headerLabel
 	const subheaderVariant = styles?.subHeaderText ?? subHeaderLabel
+	const itemVariant = styles?.tableItemsText ?? tableItems
+	const itemStyle = styles?.tableItems ?? {}
 
 	return [
 		headerVariant,
@@ -72,5 +78,7 @@ export function useTableStyles(
 		headerStyle,
 		subheaderStyle,
 		rootStyle,
+		itemStyle,
+		itemVariant,
 	]
 }

--- a/packages/themed-components-stories/stories/utils/utils.tsx
+++ b/packages/themed-components-stories/stories/utils/utils.tsx
@@ -31,11 +31,11 @@ const cardOverview = {
 
 const table = {
 	header: { color: '#f683ba', height: '10px' },
-	headerText: 'medium',
+	headerText: 'small',
 	subHeaderText: 'tiny',
 	subheader: { fontStyle: 'italic' },
 	tableItems: { fontStyle: 'italic', textAlign: 'center' },
-	tableItemsText: 'medium',
+	tableItemsText: 'large',
 	neighborExpandButton: { root: { color: 'black' } },
 	root: { background: '#ced4e4' },
 }


### PR DESCRIPTION
Fix styling for entity items (row elements). Last PR missed these files to remove memo and then didn't replace default styling in entityItem. 