### PR TITLE
Updating graphql-api-commons request context, authenticator and injectCommon

### DIFF
--- a/.yarn/versions/b0e4aec0.yml
+++ b/.yarn/versions/b0e4aec0.yml
@@ -1,0 +1,5 @@
+releases:
+  "@essex-js-toolkit/graphql-api-commons": patch
+
+declined:
+  - "@essex-js-toolkit/dev"

--- a/packages/graphql-api-commons/src/app/AppBuilder.ts
+++ b/packages/graphql-api-commons/src/app/AppBuilder.ts
@@ -61,10 +61,10 @@ export class AppBuilder<
 			introspection: this.config.serverIntrospection,
 			context: async ({ request }: { request: FastifyRequest }) => {
 				const ctx = { ...this._appContext, request: {} as RequestContext }
-				this._requestContextProviders.forEach(rcp => {
-					const result = rcp.apply(ctx, request)
+				for (const rcp of this._requestContextProviders) {
+					const result = await rcp.apply(ctx, request)
 					ctx.request = { ...ctx.request, ...result }
-				})
+				}
 				return ctx
 			},
 			debug: false,

--- a/packages/graphql-api-commons/src/authentication/types.ts
+++ b/packages/graphql-api-commons/src/authentication/types.ts
@@ -13,10 +13,12 @@ export interface IAuthenticator<Credentials, Identity> {
 	login(credentials: Credentials): Promise<Identity | null>
 
 	/**
-	 * Log iinto the system with a JWT token
+	 * Log into the system with an Authorization header
 	 * @param token The token to use
 	 */
-	verifyToken(token: string | null): Promise<Identity | null>
+	verifyAuthorization(
+		header: string | null | undefined,
+	): Promise<Identity | null>
 
 	/**
 	 * Log out of the system

--- a/packages/graphql-api-commons/src/authentication/types.ts
+++ b/packages/graphql-api-commons/src/authentication/types.ts
@@ -13,12 +13,10 @@ export interface IAuthenticator<Credentials, Identity> {
 	login(credentials: Credentials): Promise<Identity | null>
 
 	/**
-	 * Log into the system with an Authorization header
+	 * Log into the system with a JWT token
 	 * @param token The token to use
 	 */
-	verifyAuthorization(
-		header: string | null | undefined,
-	): Promise<Identity | null>
+	verifyToken(token: string | null): Promise<Identity | null>
 
 	/**
 	 * Log out of the system

--- a/packages/graphql-api-commons/src/utils/IdentityRequestContextProvider.ts
+++ b/packages/graphql-api-commons/src/utils/IdentityRequestContextProvider.ts
@@ -14,6 +14,14 @@ export interface IdentityRequestContext<Identity> {
 	identity: Identity | null
 }
 
+export type Transformer<T> = (value: T) => T
+export const stripBearerPrefix: Transformer<string | null> = header =>
+	header == null
+		? null
+		: header.indexOf('Bearer ') === 0
+		? header.slice('Bearer '.length)
+		: header
+
 export class IdentityRequestContextProvider<
 	Configuration extends IBaseConfiguration,
 	Components extends { authenticator: IAuthenticator<unknown, Identity> },
@@ -21,14 +29,26 @@ export class IdentityRequestContextProvider<
 	Identity,
 > implements RequestContextProvider<Configuration, Components, RequestContext>
 {
+	private _headerName: string
+	private _headerTransformer: Transformer<string | null>
+
+	public constructor(
+		headerName = 'authorization',
+		headerTransformer = stripBearerPrefix,
+	) {
+		this._headerTransformer = headerTransformer
+		this._headerName = headerName
+	}
+
 	public async apply(
 		ctx: IRequestAppContext<Configuration, Components, RequestContext>,
 		request: FastifyRequest,
 	): Promise<Partial<RequestContext>> {
 		const { authenticator } = ctx.components
-		const identity = await authenticator.verifyAuthorization(
-			request.headers.authorization ?? null,
+		const token = this._headerTransformer(
+			(request.headers[this._headerName] as string) ?? null,
 		)
+		const identity = await authenticator.verifyToken(token)
 		return { identity } as Partial<RequestContext>
 	}
 }

--- a/packages/graphql-api-commons/src/utils/IdentityRequestContextProvider.ts
+++ b/packages/graphql-api-commons/src/utils/IdentityRequestContextProvider.ts
@@ -26,7 +26,7 @@ export class IdentityRequestContextProvider<
 		request: FastifyRequest,
 	): Promise<Partial<RequestContext>> {
 		const { authenticator } = ctx.components
-		const identity = await authenticator.verifyToken(
+		const identity = await authenticator.verifyAuthorization(
 			request.headers.authorization ?? null,
 		)
 		return { identity } as Partial<RequestContext>

--- a/packages/graphql-api-commons/src/utils/injectCommon.ts
+++ b/packages/graphql-api-commons/src/utils/injectCommon.ts
@@ -5,17 +5,54 @@
 import { DependencyContainer } from 'tsyringe'
 import { AppBuilder, BaseInjectorNames, LoggerProvider } from '..'
 
+export type ContainerRegister = (
+	container: DependencyContainer,
+	token: BaseInjectorNames,
+) => void
+
+export interface BaseRegisters {
+	[BaseInjectorNames.Configuration]: ContainerRegister
+	[BaseInjectorNames.Schema]: ContainerRegister
+	[BaseInjectorNames.RequestContextProviders]: ContainerRegister
+	[BaseInjectorNames.AppContext]: ContainerRegister
+	[BaseInjectorNames.Logger]?: ContainerRegister
+	[BaseInjectorNames.AppBuilder]?: ContainerRegister
+}
+
 /**
  * Inject Boilerplace Components
  * @param container the DI container
+ * @param baseRegisters container registers for base injectors
  */
-export async function injectCommon(
+export function injectCommon(
 	container: DependencyContainer,
-): Promise<void> {
-	container.register(BaseInjectorNames.Logger, {
-		useValue: container.resolve(LoggerProvider).get(),
-	})
-	container.register(BaseInjectorNames.AppBuilder, {
-		useValue: container.resolve(AppBuilder),
-	})
+	baseRegisters: BaseRegisters,
+): void {
+	const registers = {
+		...baseRegisters,
+		[BaseInjectorNames.AppBuilder]:
+			baseRegisters.AppBuilder ||
+			((container, token) => {
+				container.register(token, {
+					useClass: AppBuilder,
+				})
+			}),
+		[BaseInjectorNames.Logger]:
+			baseRegisters.AppBuilder ||
+			((container, token) => {
+				container.register(token, {
+					useValue: container.resolve(LoggerProvider).get(),
+				})
+			}),
+	}
+
+	registers.Configuration(container, BaseInjectorNames.Configuration)
+	registers.Logger(container, BaseInjectorNames.Logger)
+	registers.Schema(container, BaseInjectorNames.Schema)
+	registers.RequestContextProviders(
+		container,
+		BaseInjectorNames.RequestContextProviders,
+	)
+	registers.AppContext(container, BaseInjectorNames.AppContext)
+	registers.AppBuilder(container, BaseInjectorNames.AppBuilder)
 }


### PR DESCRIPTION
- Updating request context provider to await for the promise to fulfilled
- Updating IAuthenticator to work with authorization header
- Updating injectCommon to inject base injectors