### PR TITLE
fix dropdown not opening on storybook

### DIFF
--- a/.yarn/versions/af564c2e.yml
+++ b/.yarn/versions/af564c2e.yml
@@ -1,0 +1,2 @@
+releases:
+  essex-js-toolkit-stories: patch

--- a/.yarn/versions/af564c2e.yml
+++ b/.yarn/versions/af564c2e.yml
@@ -1,2 +1,3 @@
 releases:
+  essex-js-toolkit: patch
   essex-js-toolkit-stories: patch

--- a/packages/stories/.storybook/ThematicFluentDecorator.tsx
+++ b/packages/stories/.storybook/ThematicFluentDecorator.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo, StrictMode } from 'react'
+import React, { useState, useCallback, useMemo } from 'react'
 import { Toggle } from '@fluentui/react'
 import { ThemeVariant, loadById } from '@thematic/core'
 import { ApplicationStyles } from '@thematic/react'
@@ -28,15 +28,13 @@ export const ThematicFluentDecorator = (
 		setDark(v)
 	}, [])
 	return (
-		<StrictMode>
-			<ThematicFluentProvider theme={thematicTheme}>
-				<ApplicationStyles />
-				<Toggle label="Dark mode" checked={dark} onChange={handleDarkChange} />
-				<ThemeProvider theme={thematicTheme}>
-					<Container>{storyFn(undefined, undefined)}</Container>
-				</ThemeProvider>
-			</ThematicFluentProvider>
-		</StrictMode>
+		<ThematicFluentProvider theme={thematicTheme}>
+			<ApplicationStyles />
+			<Toggle label="Dark mode" checked={dark} onChange={handleDarkChange} />
+			<ThemeProvider theme={thematicTheme}>
+				<Container>{storyFn(undefined, undefined)}</Container>
+			</ThemeProvider>
+		</ThematicFluentProvider>
 	)
 }
 


### PR DESCRIPTION
- dropdown/modals weren't opening because of strict mode on react
  - I verified that Storybook works with React v18 but doesn't fully support all it's new features, so we got a few errors on the console and they said they'll only fix it in version 7: https://github.com/storybookjs/storybook/issues/17831.